### PR TITLE
Remove ansible warning

### DIFF
--- a/tasks/node_dependencies.yml
+++ b/tasks/node_dependencies.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Vertica dependencies
   apt: name="{{item}}" state=present
-  with_items: "{{vertica_dependencies}}"
+  with_items: vertica_dependencies
   when: not skip_install
 
 - name: Setup User limits for the db


### PR DESCRIPTION
Remove this warning when running playbooks that include this role:

[WARNING]: It is unnecessary to use '{{' in loops, leave variables in loop
expressions bare.
