### PR TITLE
check vertica status before stop and start

### DIFF
--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -1,12 +1,19 @@
 ---
-- name: Start vertica DB cluster (admintools start_db)
+- name: vertica | start | check service status
+  command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
+  register: running_result
+  run_once: true
+  ignore_errors: yes
+
+- name: vertica | start | start vertica service (when down)
   command: su dbadmin -c '/opt/vertica/bin/admintools -t start_db -d {{vertica_database_name}} -p "{{vertica_dbadmin_password}}"'
   register: status_start
   failed_when: status_start | failed
   run_once: true
+  when: running_result.stdout.find("DOWN") != -1
 
-- name: wait for vertica port
+- name: vertica | start | wait for vertica port
   wait_for: port={{vertica_client_port}} host='127.0.0.1' state=started timeout={{monasca_wait_for_period}}
 
-- name: Start vertica_agent
+- name: vertica agent | start | start vertica agent service
   service: name=vertica_agent state=started

--- a/tasks/stop.yml
+++ b/tasks/stop.yml
@@ -1,9 +1,16 @@
 ---
-- name: Stop vertica DB cluster (admintools stop_db)
+- name: vertica | stop | check service status
+  command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
+  register: running_result
+  run_once: true
+  ignore_errors: yes
+
+- name: vertica | stop | stop vertica service (when up)
   command: su dbadmin -c '/opt/vertica/bin/admintools -t stop_db -d {{ vertica_database_name }} -p "{{vertica_dbadmin_password}}"'
   register: status_stop
   failed_when: status_stop | failed
   run_once: true
+  when: running_result.stdout.find("UP") != -1
 
-- name: Stop vertica_agent
+- name: vertica_agent | stop | stop vertica_agent
   service: name=vertica_agent state=stopped


### PR DESCRIPTION
stop vertica when up
start vertica when down

This will allow the case of attempting
to start or stop two times in a row to
succeed without error.
Useful for a monasca-start playbook.
