### PR TITLE
Allow deploying on CentOS

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,9 @@ galaxy_info:
   - name: Debian
     versions:
     - all
+  - name: EL
+    versions:
+    - all
   categories:
   - database
 dependencies: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,7 +6,12 @@
   sudo: true
   when: vertica_use_apt
 
-- name: Install Vertica from local
+- name: Install Vertica from local (deb)
   apt:  deb="{{vertica_package_location}}" state=installed
   sudo: true
-  when: not vertica_use_apt
+  when: not vertica_use_apt and ansible_os_family == 'Debian'
+
+- name: Install Vertica from local (yum)
+  yum:  name="{{vertica_package_location}}" state=present
+  sudo: true
+  when: not vertica_use_apt and ansible_os_family == 'RedHat'

--- a/tasks/node_dependencies.yml
+++ b/tasks/node_dependencies.yml
@@ -1,8 +1,13 @@
 ---
-- name: Install Vertica dependencies
+- name: Install Vertica dependencies (apt)
   apt: name="{{item}}" state=present
   with_items: vertica_dependencies
-  when: not skip_install
+  when: not skip_install and ansible_os_family == 'Debian'
+
+- name: Install Vertica dependencies (yum)
+  yum: name="{{item}}" state=present
+  with_items: vertica_dependencies
+  when: not skip_install and ansible_os_family == 'RedHat'
 
 - name: Setup User limits for the db
   template: dest=/etc/security/limits.d/vertica.conf owner=root group=root mode=644 src=vertica_limits.conf.j2

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ vertica_dependencies:
   - logrotate
   - pstack
   - rsync
-  - ssh
+  - "{{ 'openssh' if ansible_os_family == 'RedHat' else 'ssh' }}"
   - sysstat
   - mcelog
 # daily|weekly|monthly


### PR DESCRIPTION
Hi, I've made some small modifications to be able to deploy from CentOS, if you give it an .rpm in the vertica_package_location. Most of the dependencies have the same name, except 'ssh' which is 'openssh' on CentOS. 

I've tested deployment on CentOS 6.6; the cluster starts up and databases can be created on it. It doesn't include the changes to disable SELinux or enable EPEL repos, since I'm doing those using separate roles and it seemed a little out of scope. 

Thanks,
Jin
