### PR TITLE
Fix default SSL certificate location, suppress error highlighting in response, change logrotate permissions for Vertica Excavator

### DIFF
--- a/tasks/node_setup.yml
+++ b/tasks/node_setup.yml
@@ -87,7 +87,7 @@
   copy: dest={{vertica_config_dir}}/share/agent.pem owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 content="{{vertica_agent_pem}}"
 
 - name: Using insecure default database ssl key
-  copy: src=default_server.key dest=/var/vertica/server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 force=no
+  copy: src=default_server.key dest={{vertica_catalog_dir}}/../server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 force=no
   when: vertica_server_key is not defined
 
 - name: Using insecure default database ssl crt

--- a/tasks/node_setup.yml
+++ b/tasks/node_setup.yml
@@ -24,16 +24,16 @@
 - name: Check if database exists
   command: /opt/vertica/bin/admintools -t list_db -d {{ vertica_database_name }}
   sudo_user: dbadmin
-  ignore_errors: yes
+  failed_when: false
   register: place_key
 
 - name: Place community license key
   copy: src=community_license.key dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=664
-  when: vertica_license is not defined and place_key|failed
+  when: vertica_license is not defined and place_key.rc != 0
 
 - name: Place license key
   copy: content="{{vertica_license}}" dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=664
-  when: vertica_license is defined and place_key|failed
+  when: vertica_license is defined and place_key.rc != 0
 
 # reads in the agent ssh keys from the first host as it will the use the same keys throughout the cluster
 - name: Set agent keys from the first host

--- a/tasks/node_setup.yml
+++ b/tasks/node_setup.yml
@@ -23,6 +23,10 @@
 - name: Create file for EULA acceptance
   copy: src=d5415f948449e9d4c421b568f2411140.dat dest={{vertica_config_dir}}/d5415f948449e9d4c421b568f2411140.dat owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=775
 
+# Required for Vertica 7.2 since it writes a logrotate file when creating the database as the dbadmin user.
+- name: Set logrotate folder permissions
+  file: path=/opt/vertica/config/logrotate/ state=directory owner={{vertica_dbadmin_user}} group={{vertica_dbadmin_group}}
+
 - name: Check if database exists
   command: /opt/vertica/bin/admintools -t list_db -d {{ vertica_database_name }}
   sudo_user: dbadmin

--- a/tasks/node_setup.yml
+++ b/tasks/node_setup.yml
@@ -26,6 +26,7 @@
 - name: Check if database exists
   command: /opt/vertica/bin/admintools -t list_db -d {{ vertica_database_name }}
   sudo_user: dbadmin
+  changed_when: false
   failed_when: false
   register: place_key
 

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -5,6 +5,7 @@
   command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
   register: running_result
   run_once: true
+  changed_when: false
   failed_when: false
 
 - name: vertica | start | start vertica service (when down)

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -3,7 +3,7 @@
   command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
   register: running_result
   run_once: true
-  ignore_errors: yes
+  failed_when: false
 
 - name: vertica | start | start vertica service (when down)
   command: su dbadmin -c '/opt/vertica/bin/admintools -t start_db -d {{vertica_database_name}} -p "{{vertica_dbadmin_password}}"'

--- a/tasks/stop.yml
+++ b/tasks/stop.yml
@@ -5,6 +5,7 @@
   command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
   register: running_result
   run_once: true
+  changed_when: false
   failed_when: false
 
 - name: vertica | stop | stop vertica service (when up)

--- a/tasks/stop.yml
+++ b/tasks/stop.yml
@@ -3,7 +3,7 @@
   command: su dbadmin -c '/opt/vertica/bin/admintools -t view_cluster -d {{vertica_database_name}}'
   register: running_result
   run_once: true
-  ignore_errors: yes
+  failed_when: false
 
 - name: vertica | stop | stop vertica service (when up)
   command: su dbadmin -c '/opt/vertica/bin/admintools -t stop_db -d {{ vertica_database_name }} -p "{{vertica_dbadmin_password}}"'


### PR DESCRIPTION
Hi, 

This is a really minor change, but would you consider using failed_when: false instead of ignore_errors: true ? 

This is just to avoid printing a red error on the screen when it's actually an expected error, so the visual output changes from e.g.
![screenshot from 2015-09-29 16 00 39](https://cloud.githubusercontent.com/assets/7871081/10168945/ca2a3f12-66c6-11e5-8762-acba8fa053a6.png)
to a normal-coloured line: 
![screenshot from 2015-09-29 17 45 32](https://cloud.githubusercontent.com/assets/7871081/10171419/f7676774-66d1-11e5-9eae-6fa21c371d81.png)

Optionally we could put changed_when: false as well, so it'll just say 'ok' instead of 'changed', I can update the pull to do that if you like. 

(edit: done this, and fixed a SSL default path as well)

Thanks,
Jin
