### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -10,7 +10,7 @@
   register: admin_tools_status
 
 - name: Create admintools config file
-  template: src=admintools.conf.j2 dest={{vertica_config_dir}}/admintools.conf owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=660
+  template: src=admintools.conf.j2 dest={{vertica_config_dir}}/admintools.conf owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0660
   when: not admin_tools_status.stat.exists
 
 - name: Build hosts file if inventory entry is defined with hostname
@@ -24,7 +24,7 @@
   with_items: vertica_group
 
 - name: Create the vertica_script_location
-  file: path={{vertica_script_location}} state=directory owner=root group=root mode=755
+  file: path={{vertica_script_location}} state=directory owner=root group=root mode=0755
 
 - name: Create recovery script
-  template: src=vertica_recovery.j2 dest={{vertica_script_location}}/vertica_recovery mode=740
+  template: src=vertica_recovery.j2 dest={{vertica_script_location}}/vertica_recovery mode=0740

--- a/tasks/configure_logrotate.yml
+++ b/tasks/configure_logrotate.yml
@@ -11,4 +11,4 @@
   set_fact: vertica_node_name={{vertica_node.stdout}}
 
 - name: Place logrotate conf for vertica
-  template: src=vertica_logrotate.j2 dest=/opt/vertica/config/logrotate/{{ vertica_database_name }} owner=root group=root mode=644
+  template: src=vertica_logrotate.j2 dest=/opt/vertica/config/logrotate/{{ vertica_database_name }} owner=root group=root mode=0644

--- a/tasks/node_dependencies.yml
+++ b/tasks/node_dependencies.yml
@@ -12,7 +12,7 @@
   when: not skip_install and ansible_os_family == 'RedHat'
 
 - name: Setup User limits for the db
-  template: dest=/etc/security/limits.d/vertica.conf owner=root group=root mode=644 src=vertica_limits.conf.j2
+  template: dest=/etc/security/limits.d/vertica.conf owner=root group=root mode=0644 src=vertica_limits.conf.j2
 
 - name: Apply security limits to su sessions, admintools needs this as it uses su
   lineinfile: dest=/etc/pam.d/su regexp="^#\ssession    required   pam_limits.so" line="session    required   pam_limits.so" backrefs=yes
@@ -23,7 +23,7 @@
     content: "export LANG='en_US.UTF-8'\nexport LC_ALL='en_US.UTF-8'\n"
     owner: root
     group: root
-    mode: 644
+    mode: 0644
 
 - name: Create en_US.UTF-8 locale
   shell: localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/tasks/node_setup.yml
+++ b/tasks/node_setup.yml
@@ -2,13 +2,13 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: Create catalog and data directory
-  file: path={{item}} owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=770 state=directory
+  file: path={{item}} owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0770 state=directory
   with_items:
     - "{{vertica_catalog_dir}}"
     - "{{vertica_data_dir}}"
 
 - name: Create vertica_config_dir, share, and log directories
-  file: path={{item}} owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=775 state=directory
+  file: path={{item}} owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0775 state=directory
   with_items:
     - "{{vertica_config_dir}}"
     - /opt/vertica/config/share
@@ -21,7 +21,7 @@
     - { dest: '/etc/init.d/verticad', src: '/opt/vertica/sbin/verticad' }
 
 - name: Create file for EULA acceptance
-  copy: src=d5415f948449e9d4c421b568f2411140.dat dest={{vertica_config_dir}}/d5415f948449e9d4c421b568f2411140.dat owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=775
+  copy: src=d5415f948449e9d4c421b568f2411140.dat dest={{vertica_config_dir}}/d5415f948449e9d4c421b568f2411140.dat owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0775
 
 # Required for Vertica 7.2 since it writes a logrotate file when creating the database as the dbadmin user.
 - name: Set logrotate folder permissions
@@ -35,11 +35,11 @@
   register: place_key
 
 - name: Place community license key
-  copy: src=community_license.key dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=664
+  copy: src=community_license.key dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0664
   when: vertica_license is not defined and place_key.rc != 0
 
 - name: Place license key
-  copy: content="{{vertica_license}}" dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=664
+  copy: content="{{vertica_license}}" dest={{vertica_config_dir}}/share/license.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0664
   when: vertica_license is defined and place_key.rc != 0
 
 # reads in the agent ssh keys from the first host as it will the use the same keys throughout the cluster
@@ -82,26 +82,26 @@
   when: vertica_agent_key is not defined
 
 - name: Create agent key
-  copy: dest={{vertica_config_dir}}/share/agent.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 content="{{vertica_agent_key}}"
+  copy: dest={{vertica_config_dir}}/share/agent.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0400 content="{{vertica_agent_key}}"
 
 - name: Create agent cert
-  copy: dest={{vertica_config_dir}}/share/agent.cert owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 content="{{vertica_agent_cert}}"
+  copy: dest={{vertica_config_dir}}/share/agent.cert owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0400 content="{{vertica_agent_cert}}"
 
 - name: Create agent pem
-  copy: dest={{vertica_config_dir}}/share/agent.pem owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 content="{{vertica_agent_pem}}"
+  copy: dest={{vertica_config_dir}}/share/agent.pem owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0400 content="{{vertica_agent_pem}}"
 
 - name: Using insecure default database ssl key
-  copy: src=default_server.key dest={{vertica_catalog_dir}}/../server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 force=no
+  copy: src=default_server.key dest={{vertica_catalog_dir}}/../server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0400 force=no
   when: vertica_server_key is not defined
 
 - name: Using insecure default database ssl crt
-  copy: src=default_server.crt dest={{vertica_catalog_dir}}/../server.crt owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=444 force=no
+  copy: src=default_server.crt dest={{vertica_catalog_dir}}/../server.crt owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0444 force=no
   when: vertica_server_crt is not defined
 
 - name: Create server key from variable
-  copy: dest={{vertica_catalog_dir}}/../server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=400 content="{{vertica_server_key}}" force=no
+  copy: dest={{vertica_catalog_dir}}/../server.key owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0400 content="{{vertica_server_key}}" force=no
   when: vertica_server_key is defined
 
 - name: Create server crt from variable
-  copy: dest={{vertica_catalog_dir}}/../server.crt owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=444 content="{{vertica_server_crt}}" force=no
+  copy: dest={{vertica_catalog_dir}}/../server.crt owner="{{vertica_dbadmin_user}}" group="{{vertica_dbadmin_group}}" mode=0444 content="{{vertica_server_crt}}" force=no
   when: vertica_server_crt is defined


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
